### PR TITLE
Use an appropriate max cache size

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -23,6 +23,6 @@ module "loris_2020_02_18" {
   # See: https://github.com/wellcometrust/dockerfiles
   ebs_cache_cleaner_daemon_image_version = "39"
 
-  ebs_cache_cleaner_daemon_max_size_in_gb = "1"
+  ebs_cache_cleaner_daemon_max_size_in_gb = "160"
   ebs_cache_cleaner_daemon_clean_interval = "1m"
 }


### PR DESCRIPTION
Unless there's a reason I'm missing, it looks like we should be using a _much_ bigger max cache size here - I've copied the variable default from `stack/variables.tf`.

I don't really know how to deploy Loris (slightly confused by the date-namespaced stack) but that can wait for https://github.com/loris-imageserver/loris/pull/504 as well.