### PR TITLE
Increase EBS volume size, decrease max cache size

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -23,6 +23,7 @@ module "loris_2020_02_18" {
   # See: https://github.com/wellcometrust/dockerfiles
   ebs_cache_cleaner_daemon_image_version = "144"
 
-  ebs_cache_cleaner_daemon_max_size_in_gb = "160"
+  ebs_size                                = "200"
+  ebs_cache_cleaner_daemon_max_size_in_gb = "150"
   ebs_cache_cleaner_daemon_clean_interval = "1m"
 }


### PR DESCRIPTION
In my ongoing campaign to destroy Loris, I've found that at _sustained_ high throughput it's possible to "beat" the cache cleaner and fill up the EBS volume faster than the filesystem can be walked on a very-cpu-busy, very-read-heavy instance.

Hopefully this will increase that buffer size so that this doesn't happen!