### PR TITLE
Use a the uwsgi protocol over a unix socket for nginx-loris comms

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,15 +19,6 @@ This project has the Docker image and infrastructure for our [Loris][loris] depl
 
 3.  Plan and apply the terraform in the `terraform` directory.
 
-## Running Loris in development mode
-
-Sometimes it can be convenient to test Loris locally, without pushing a new commit to GitHub -- e.g. for testing a code patch, or experimenting with config.
-You can run Loris locally with the following two commands:
-
-    make loris-run
-
-You'll then have a development version of Loris running at <http://localhost:8888>.
-
 ## Testing Loris with nginx
 
 In order to test Loris with its nginx config this project provides a `docker-compose.yml`
@@ -39,12 +30,7 @@ This can be run using (substituting env variables as necessary):
 This starts both loris and nginx (at the tag specified), using the config file specified.
 
 ```sh
-CONFIG_KEY=location/of/config.ini \
-NGINX_TAG=latest \
-AWS_ACCESS_KEY_ID=key_id \
-AWS_SECRET_ACCESS_KEY=access_key \
-docker-compose up
-
+NGINX_TAG=latest docker-compose up
 ```
 
 ### curl localhost:9000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,19 @@
-app:
-  build: .
-  ports:
-   - "8888:8888"
-nginx:
-  image: "nginx_loris:${NGINX_TAG}"
-  ports:
-   - "9000:9000"
+version: "3"
+
+services:
+  app:
+    build: ./loris
+    image: loris
+    volumes:
+      - uwsgi_sock_dir:/var/run/uwsgi
+  nginx:
+    # You will probably want to build a local version of this image
+    # which disables the HTTPS redirection logic
+    image: "nginx_loris:${NGINX_TAG:-latest}"
+    ports:
+     - "9000:9000"
+    volumes:
+     - uwsgi_sock_dir:/var/run/uwsgi
+
+volumes:
+  uwsgi_sock_dir:

--- a/loris/uwsgi.ini
+++ b/loris/uwsgi.ini
@@ -3,5 +3,9 @@ strict = true
 master = true
 plugins = python3
 wsgi-file = /var/www/loris2/loris2.wsgi
-http-socket = :8888
 processes = 64
+
+socket = /var/run/uwsgi/loris.sock
+chmod-socket = 666
+vacuum = true
+die-on-term = true

--- a/terraform/stack/main.tf
+++ b/terraform/stack/main.tf
@@ -7,64 +7,121 @@ resource "aws_ecs_cluster" "cluster" {
   name = var.namespace
 }
 
+resource "aws_cloudwatch_log_group" "sidecar_log_group" {
+  name              = "ecs/sidecar_${var.namespace}"
+  retention_in_days = 7
+}
+
+resource "aws_cloudwatch_log_group" "app_log_group" {
+  name              = "ecs/${var.namespace}"
+  retention_in_days = 7
+}
+
+data "aws_region" "current" {}
+
 locals {
-  sidecar_container_name = "sidecar"
+  uwsgi_socket_volume = "uwsgi_socket"
+  uwsgi_socket_dir    = "/var/run/uwsgi"
+}
+
+module "sidecar_container" {
+  source = "github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/container_definition?ref=v2.4.1"
+
+  name  = "sidecar"
+  image = var.sidecar_container_image
+
+  cpu    = var.sidecar_cpu
+  memory = var.sidecar_memory
+
+  mount_points = [
+    {
+      sourceVolume  = local.uwsgi_socket_volume
+      containerPath = local.uwsgi_socket_dir
+    }
+  ]
+  port_mappings = [
+    {
+      containerPort = var.sidecar_container_port
+      hostPort      = var.sidecar_container_port
+      protocol      = "tcp"
+    }
+  ]
+
+  log_configuration = {
+    logDriver = "awslogs"
+    options = {
+      awslogs-group         = aws_cloudwatch_log_group.sidecar_log_group.name
+      awslogs-region        = data.aws_region.current.name
+      awslogs-stream-prefix = "ecs"
+    }
+    secretOptions = []
+  }
+}
+
+module "app_container" {
+  source = "github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/container_definition?ref=v2.4.1"
+
+  name  = "app"
+  image = var.app_container_image
+
+  cpu    = var.app_cpu
+  memory = var.app_memory
+  mount_points = [
+    {
+      sourceVolume  = "ebs",
+      containerPath = var.ebs_container_path
+    },
+    {
+      sourceVolume  = local.uwsgi_socket_volume
+      containerPath = local.uwsgi_socket_dir
+    }
+  ]
+
+  log_configuration = {
+    logDriver = "awslogs"
+    options = {
+      awslogs-group         = aws_cloudwatch_log_group.app_log_group.name
+      awslogs-region        = data.aws_region.current.name
+      awslogs-stream-prefix = "ecs"
+    }
+    secretOptions = []
+  }
 }
 
 module "task" {
-  source = "github.com/wellcomecollection/terraform-aws-ecs-service.git//task_definition/container_with_sidecar?ref=v1.3.0"
+  source = "github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/task_definition?ref=v2.5.1"
 
   task_name = var.namespace
+  cpu       = var.app_cpu + var.sidecar_cpu
+  memory    = var.app_memory + var.sidecar_memory
 
-  cpu    = var.app_cpu + var.sidecar_cpu
-  memory = var.app_memory + var.sidecar_memory
-
-  use_awslogs = true
-
-  app_container_image = var.app_container_image
-  app_container_port  = var.app_container_port
-  app_cpu             = var.app_cpu
-  app_memory          = var.app_memory
-
-  app_mount_points = [
-    {
-      sourceVolume  = "ebs"
-      containerPath = var.ebs_container_path
-    },
+  container_definitions = [
+    module.app_container.container_definition,
+    module.sidecar_container.container_definition
   ]
-
-  sidecar_container_image = var.sidecar_container_image
-  sidecar_container_port  = var.sidecar_container_port
-  sidecar_cpu             = var.sidecar_cpu
-  sidecar_memory          = var.sidecar_memory
-  sidecar_container_name  = local.sidecar_container_name
 
   ebs_volume_name = "ebs"
   ebs_host_path   = "/ebs/loris"
+  bind_mount_volumes = [
+    {
+      name      = local.uwsgi_socket_volume
+      host_path = ""
+    }
+  ]
 
-  launch_type = "EC2"
-
-  aws_region = var.aws_region
+  launch_types = ["EC2"]
 }
 
 module "service" {
-  source = "github.com/wellcomecollection/terraform-aws-ecs-service.git//service?ref=v1.3.0"
+  source = "github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/service?ref=v2.4.1"
 
-  service_name = var.namespace
   cluster_arn  = aws_ecs_cluster.cluster.arn
-
-  desired_task_count = max(2, var.desired_task_count)
+  service_name = var.namespace
 
   task_definition_arn = module.task.arn
-
-  subnets = var.private_subnets
-
-  namespace_id = aws_service_discovery_private_dns_namespace.namespace.id
-
-  security_group_ids = [
-    aws_security_group.service_lb_security_group.id,
-    aws_security_group.service_egress_security_group.id,
-  ]
+  desired_task_count  = max(2, var.desired_task_count)
+  container_name      = "sidecar"
+  container_port      = var.sidecar_container_port
 
   # We always run at least 2 instances.  Setting the minimum healthy percent
   # to 50% means that ECS can scale down tasks during deployment (but there's
@@ -74,10 +131,13 @@ module "service" {
   # See https://github.com/wellcomecollection/docs/blob/master/research/2020-01-14-ecs-scaling-big-tasks.md
   deployment_minimum_healthy_percent = 50
   deployment_maximum_percent         = 200
+  launch_type                        = "EC2"
 
-  launch_type = "EC2"
-
+  service_discovery_namespace_id = aws_service_discovery_private_dns_namespace.namespace.id
+  subnets                        = var.private_subnets
+  security_group_ids = [
+    aws_security_group.service_lb_security_group.id,
+    aws_security_group.service_egress_security_group.id,
+  ]
   target_group_arn = aws_alb_target_group.http.arn
-  container_name   = local.sidecar_container_name
-  container_port   = var.sidecar_container_port
 }

--- a/terraform/stack/main.tf
+++ b/terraform/stack/main.tf
@@ -25,7 +25,7 @@ locals {
 }
 
 module "sidecar_container" {
-  source = "github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/container_definition?ref=v2.4.1"
+  source = "github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/container_definition?ref=v2.5.0"
 
   name  = "sidecar"
   image = var.sidecar_container_image
@@ -59,7 +59,7 @@ module "sidecar_container" {
 }
 
 module "app_container" {
-  source = "github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/container_definition?ref=v2.4.1"
+  source = "github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/container_definition?ref=v2.5.0"
 
   name  = "app"
   image = var.app_container_image
@@ -89,7 +89,7 @@ module "app_container" {
 }
 
 module "task" {
-  source = "github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/task_definition?ref=v2.5.1"
+  source = "github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/task_definition?ref=v2.5.0"
 
   task_name = var.namespace
   cpu       = var.app_cpu + var.sidecar_cpu
@@ -102,7 +102,7 @@ module "task" {
 
   ebs_volume_name = "ebs"
   ebs_host_path   = "/ebs/loris"
-  bind_mount_volumes = [
+  extra_volumes = [
     {
       name      = local.uwsgi_socket_volume
       host_path = ""
@@ -113,7 +113,7 @@ module "task" {
 }
 
 module "service" {
-  source = "github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/service?ref=v2.4.1"
+  source = "github.com/wellcomecollection/terraform-aws-ecs-service.git//modules/service?ref=v2.5.0"
 
   cluster_arn  = aws_ecs_cluster.cluster.arn
   service_name = var.namespace


### PR DESCRIPTION
We were running out of TCP sockets on the host at high throughput - this is the [recommended](https://uwsgi-docs.readthedocs.io/en/latest/Nginx.html) way to configure an nginx reverse proxy in front of a uWSGI server.

Depends on https://github.com/wellcomecollection/platform-infrastructure/pull/20
Depends on https://github.com/wellcomecollection/terraform-aws-ecs-service/pull/20 